### PR TITLE
Bring Ditmars compatibility

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ There are several samples, most running on the RabbitMQ transport (so you need R
 To build the samples do:
 
 ```
-   ./mvnw clean build
+   ./mvnw clean install
 ```
 
 

--- a/double/pom.xml
+++ b/double/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/dynamic-source/pom.xml
+++ b/dynamic-source/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/kinesis-produce-consume/pom.xml
+++ b/kinesis-produce-consume/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<repositories>

--- a/kstream/pom.xml
+++ b/kstream/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-stream-samples</artifactId>
-        <version>1.2.0.BUILD-SNAPSHOT</version>
+        <version>1.3.0.BUILD-SNAPSHOT</version>
     </parent>
 
    <modules>

--- a/multi-io/pom.xml
+++ b/multi-io/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/multibinder-differentsystems/pom.xml
+++ b/multibinder-differentsystems/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -41,8 +41,8 @@
 			<artifactId>spring-cloud-stream-binder-kafka</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-kafka-test-support</artifactId>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/multibinder/pom.xml
+++ b/multibinder/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -36,8 +36,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-stream-binder-kafka-test-support</artifactId>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/non-self-contained-aggregate-app/pom.xml
+++ b/non-self-contained-aggregate-app/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-stream-samples</artifactId>
-	<version>1.2.0.BUILD-SNAPSHOT</version>
+	<version>1.3.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<url>https://github.com/spring-cloud/spring-cloud-stream-samples</url>
 	<organization>
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.5.RELEASE</version>
+		<version>1.3.6.RELEASE</version>
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -28,7 +28,7 @@
 		<module>non-self-contained-aggregate-app</module>
 		<module>multibinder</module>
 		<module>multibinder-differentsystems</module>
-		<module>rxjava-processor</module>
+		<!-- <module>rxjava-processor</module> -->
 		<module>multi-io</module>
 		<module>stream-listener</module>
 		<module>reactive-processor-kafka</module>

--- a/reactive-processor-kafka/pom.xml
+++ b/reactive-processor-kafka/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-stream-samples</artifactId>
         <groupId>org.springframework.cloud</groupId>
-        <version>1.2.0.BUILD-SNAPSHOT</version>
+        <version>1.3.0.BUILD-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/rxjava-processor/pom.xml
+++ b/rxjava-processor/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/sink/pom.xml
+++ b/sink/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/stream-listener/pom.xml
+++ b/stream-listener/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/test-embedded-kafka/pom.xml
+++ b/test-embedded-kafka/pom.xml
@@ -12,7 +12,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-stream-samples</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.3.0.BUILD-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
- Fix README bug
- Adapt to KafkaEmbedded changes in SCSt (since it is moved to Spring Kafka)
- Update pom's to be on 1.3.0.BUILD-SNAPSHOT
- Comment-out rxJava module  - we may have to deprecate it since the core functionality is deprecated in SCSt