### PR TITLE
URL Cleanup

### DIFF
--- a/kafka-streams-samples/kafka-streams-interactive-query-advanced/src/main/java/kafka/streams/interactive/query/KafkaStreamsInteractiveQuerySample.java
+++ b/kafka-streams-samples/kafka-streams-interactive-query-advanced/src/main/java/kafka/streams/interactive/query/KafkaStreamsInteractiveQuerySample.java
@@ -200,7 +200,7 @@ public class KafkaStreamsInteractiveQuerySample {
 				logger.info("Top Five songs request served from different host: " + hostInfo);
 				RestTemplate restTemplate = new RestTemplate();
 				return restTemplate.postForObject(
-						String.format("http://%s:%d/%s", hostInfo.host(),
+						String.format("https://%s:%d/%s", hostInfo.host(),
 								hostInfo.port(), "charts/top-five?genre=Punk"), "punk", List.class);
 			}
 		}
@@ -235,7 +235,7 @@ public class KafkaStreamsInteractiveQuerySample {
 					logger.info("Song info request served from different host: " + hostInfo);
 					RestTemplate restTemplate = new RestTemplate();
 					SongBean song = restTemplate.postForObject(
-							String.format("http://%s:%d/%s", hostInfo.host(),
+							String.format("https://%s:%d/%s", hostInfo.host(),
 									hostInfo.port(), "song/idx?id=" + songPlayCount.getSongId()),  "id", SongBean.class);
 					results.add(new SongPlayCountBean(song.getArtist(),song.getAlbum(), song.getName(),
 							songPlayCount.getPlays()));

--- a/processor-samples/polled-consumer/README.md
+++ b/processor-samples/polled-consumer/README.md
@@ -18,7 +18,7 @@ It uses a Polled Consumer (rather than a message-driven `@StreamListener`).
 * PolledConsumerApplicationTests - the test case
 
 The `spring-kafka-test` dependency added to the `pom.xml` puts the `KafkaEmbedded` JUnit `@Rule` on the class path.
-Refer to the [Spring for Apache Kafka Reference Manual](http://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
+Refer to the [Spring for Apache Kafka Reference Manual](https://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
 Notice how the `@BeforeClass` method sets up the Boot and binder properties to locate the servers.
 
 See the test method for the details on interacting with Embedded Kafka.

--- a/testing-samples/test-embedded-kafka/README.adoc
+++ b/testing-samples/test-embedded-kafka/README.adoc
@@ -17,7 +17,7 @@ This sample is a Spring Boot application that uses Spring Cloud Stream to receiv
 * EmbeddedKafkaApplicationTests - the test case
 
 The `spring-kafka-test` dependency added to the `pom.xml` puts the `KafkaEmbedded` JUnit `@Rule` on the class path.
-Refer to the [Spring for Apache Kafka Reference Manual](http://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
+Refer to the [Spring for Apache Kafka Reference Manual](https://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
 Notice how the `@BeforeClass` method sets up the Boot and binder properties to locate the servers.
 
 See the test method for the details on interacting with Embedded Kafka.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://%s:%d/%s (UnknownHostException) with 2 occurrences migrated to:  
  https://%s:%d/%s ([https](https://%s:%d/%s) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-kafka/reference/htmlsingle/ with 2 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/reference/htmlsingle/ ([https](https://docs.spring.io/spring-kafka/reference/htmlsingle/) result 301).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8081/config with 2 occurrences
* http://localhost with 2 occurrences
* http://localhost:15672 with 1 occurrences
* http://localhost:64398/ with 1 occurrences
* http://localhost:64399/orders with 1 occurrences
* http://localhost:8080 with 8 occurrences
* http://localhost:8080/ with 1 occurrences
* http://localhost:8080/charts/top-five?genre=Punk with 1 occurrences
* http://localhost:8080/events with 2 occurrences
* http://localhost:8081 with 14 occurrences
* http://localhost:8082/charts/top-five?genre=Punk with 1 occurrences
* http://localhost:8990 with 4 occurrences
* http://localhost:9009/messages with 9 occurrences
* http://localhost:9009/messagesX with 1 occurrences
* http://localhost:9010/messages with 6 occurrences
* http://localhost:9010/messagesX with 1 occurrences