### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,7 +34,7 @@ To build the samples do:
 * `stream-listener` shows how to use StreamListener support to enable message mapping and automatic type conversion.
 
 * `test-embedded-kafka` is a sample that shows how to test with an embedded Apache Kafka broker.
-We generally recommend testing with the http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_testing[TestSupportBinder] but if you have a need for testing with an embedded broker, you can use the techniques in this sample.
+We generally recommend testing with the https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_testing[TestSupportBinder] but if you have a need for testing with an embedded broker, you can use the techniques in this sample.
 
 * `transform` is a simple pass through logging transformer (just logs the incoming message and passes it on).
 

--- a/test-embedded-kafka/README.md
+++ b/test-embedded-kafka/README.md
@@ -17,7 +17,7 @@ This sample is a Spring Boot application that uses Spring Cloud Stream to receiv
 * EmbeddedKafkaApplicationTests - the test case
 
 The `spring-kafka-test` dependency added to the `pom.xml` puts the `KafkaEmbedded` JUnit `@Rule` on the class path.
-Refer to the [Spring for Apache Kafka Reference Manual](http://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
+Refer to the [Spring for Apache Kafka Reference Manual](https://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
 Notice how the `@BeforeClass` method sets up the Boot and binder properties to locate the servers.
 
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-kafka/reference/htmlsingle/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/reference/htmlsingle/ ([https](https://docs.spring.io/spring-kafka/reference/htmlsingle/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080 with 2 occurrences
* http://localhost:8080/ with 1 occurrences