### PR TITLE
URL Cleanup

### DIFF
--- a/processor-samples/polled-consumer/README.md
+++ b/processor-samples/polled-consumer/README.md
@@ -18,7 +18,7 @@ It uses a Polled Consumer (rather than a message-driven `@StreamListener`).
 * PolledConsumerApplicationTests - the test case
 
 The `spring-kafka-test` dependency added to the `pom.xml` puts the `KafkaEmbedded` JUnit `@Rule` on the class path.
-Refer to the [Spring for Apache Kafka Reference Manual](http://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
+Refer to the [Spring for Apache Kafka Reference Manual](https://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
 Notice how the `@BeforeClass` method sets up the Boot and binder properties to locate the servers.
 
 See the test method for the details on interacting with Embedded Kafka.

--- a/testing-samples/test-embedded-kafka/README.adoc
+++ b/testing-samples/test-embedded-kafka/README.adoc
@@ -17,7 +17,7 @@ This sample is a Spring Boot application that uses Spring Cloud Stream to receiv
 * EmbeddedKafkaApplicationTests - the test case
 
 The `spring-kafka-test` dependency added to the `pom.xml` puts the `KafkaEmbedded` JUnit `@Rule` on the class path.
-Refer to the [Spring for Apache Kafka Reference Manual](http://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
+Refer to the [Spring for Apache Kafka Reference Manual](https://docs.spring.io/spring-kafka/reference/htmlsingle/#testing) for more information about this.
 Notice how the `@BeforeClass` method sets up the Boot and binder properties to locate the servers.
 
 See the test method for the details on interacting with Embedded Kafka.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-kafka/reference/htmlsingle/ (301) with 2 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/reference/htmlsingle/ ([https](https://docs.spring.io/spring-kafka/reference/htmlsingle/) result 404).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1:8081/config with 1 occurrences
* http://localhost:15672 with 1 occurrences
* http://localhost:64398/ with 1 occurrences
* http://localhost:64399/orders with 1 occurrences
* http://localhost:8080 with 8 occurrences
* http://localhost:8080/ with 1 occurrences
* http://localhost:8080/charts/top-five?genre=Punk with 1 occurrences
* http://localhost:8080/events with 1 occurrences
* http://localhost:8081 with 8 occurrences
* http://localhost:8990 with 3 occurrences
* http://localhost:9009/messages with 6 occurrences
* http://localhost:9009/messagesX with 1 occurrences
* http://localhost:9010/messages with 4 occurrences
* http://localhost:9010/messagesX with 1 occurrences