### PR TITLE
#150 - Removed deprecated class KafkaEmbedded

### DIFF
--- a/testing-samples/test-embedded-kafka/src/test/java/demo/EmbeddedKafkaApplicationTests.java
+++ b/testing-samples/test-embedded-kafka/src/test/java/demo/EmbeddedKafkaApplicationTests.java
@@ -45,7 +45,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -71,16 +71,16 @@ public class EmbeddedKafkaApplicationTests {
 	private static final String GROUP_NAME = "embeddedKafkaApplication";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, OUTPUT_TOPIC);
+	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, OUTPUT_TOPIC);
 
 	@BeforeClass
 	public static void setup() {
-		System.setProperty("spring.cloud.stream.kafka.binder.brokers", embeddedKafka.getBrokersAsString());
+		System.setProperty("spring.cloud.stream.kafka.binder.brokers", embeddedKafka.getEmbeddedKafka().getBrokersAsString());
 	}
 
 	@Test
 	public void testSendReceive() {
-		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
 		senderProps.put("key.serializer", ByteArraySerializer.class);
 		senderProps.put("value.serializer", ByteArraySerializer.class);
 		DefaultKafkaProducerFactory<byte[], byte[]> pf = new DefaultKafkaProducerFactory<>(senderProps);
@@ -88,7 +88,7 @@ public class EmbeddedKafkaApplicationTests {
 		template.setDefaultTopic(INPUT_TOPIC);
 		template.sendDefault("foo".getBytes());
 
-		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(GROUP_NAME, "false", embeddedKafka);
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(GROUP_NAME, "false", embeddedKafka.getEmbeddedKafka());
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		consumerProps.put("key.deserializer", ByteArrayDeserializer.class);
 		consumerProps.put("value.deserializer", ByteArrayDeserializer.class);


### PR DESCRIPTION
#150 - Removed deprecated class org.springframework.kafka.test.rule.KafkaEmbedded, changed to new class org.springframework.kafka.test.rule.EmbeddedKafkaRule.
