### PR TITLE
README updated and docker-compose file cleanup

### DIFF
--- a/processor-samples/reactive-processor-kafka/README.adoc
+++ b/processor-samples/reactive-processor-kafka/README.adoc
@@ -18,7 +18,7 @@ The following instructions assume that you are running Kafka as a Docker image.
 
 * `./mvnw clean package`
 
-* `java -jar target/reactive-processor-0.0.1-SNAPSHOT-kafka.jar`
+* `java -jar target/reactive-processor-kafka-0.0.1-SNAPSHOT.jar`
 
 The main application contains the reactive processor that receives textual data for a duration and aggregates them.
 It then sends the aggregated data through the outbound destination of the processor.
@@ -38,15 +38,3 @@ Data received: foobarfoobarfoo
 ```
 
 * `docker-compose down`
-
-## Running the application using Rabbit binder
-
-All the instructions above apply here also, but instead of running the default `docker-compose.yml`, use the command below to start a Rabbitmq cluser.
-
-* `docker-compose -f docker-compose-rabbit.yml up -d`
-
-* `./mvnw clean package -P rabbit-binder`
-
-* `java -jar target/reactive-processor-0.0.1-SNAPSHOT-rabbit.jar`
-
-Once you are done testing: `docker-compose -f docker-compose-rabbit.yml down`

--- a/processor-samples/reactive-processor-kafka/docker-compose-rabbit.yml
+++ b/processor-samples/reactive-processor-kafka/docker-compose-rabbit.yml
@@ -1,7 +1,0 @@
-version: '3'
-services:
-  rabbitmq:
-    image: rabbitmq:management
-    ports:
-      - 5672:5672
-      - 15672:15672

--- a/processor-samples/reactive-processor-rabbit/README.adoc
+++ b/processor-samples/reactive-processor-rabbit/README.adoc
@@ -11,14 +11,14 @@ To run this sample, you will need to have installed:
 
 ## Running the application
 
-The following instructions assume that you are running Kafka as a Docker image.
+The following instructions assume that you are running RabbitMQ as a Docker image.
 
 * Go to the application root (not the repository root, but this application)
 * `docker-compose up -d`
 
 * `./mvnw clean package`
 
-* `java -jar target/reactive-processor-0.0.1-SNAPSHOT-kafka.jar`
+* `java -jar target/reactive-processor-rabbit-0.0.1-SNAPSHOT.jar`
 
 The main application contains the reactive processor that receives textual data for a duration and aggregates them.
 It then sends the aggregated data through the outbound destination of the processor.
@@ -38,15 +38,3 @@ Data received: foobarfoobarfoo
 ```
 
 * `docker-compose down`
-
-## Running the application using Rabbit binder
-
-All the instructions above apply here also, but instead of running the default `docker-compose.yml`, use the command below to start a Rabbitmq cluser.
-
-* `docker-compose -f docker-compose-rabbit.yml up -d`
-
-* `./mvnw clean package -P rabbit-binder`
-
-* `java -jar target/reactive-processor-0.0.1-SNAPSHOT-rabbit.jar`
-
-Once you are done testing: `docker-compose -f docker-compose-rabbit.yml down`


### PR DESCRIPTION
The target Jar was misspelled in the `README.md` files of the directories `processor-samples/reactive-processor-kafka` and `processor-samples/reactive-processor-rabbit`. 

So I corrected the `processor-samples/reactive-processor-kafka/README.md` instruction from `java -jar target/reactive-processor-0.0.1-SNAPSHOT-kafka.jar` to `java -jar target/reactive-processor-kafka-0.0.1-SNAPSHOT.jar` and made a corresponding correction to `processor-samples/reactive-processor-rabbit/README.md`, too.

Since there are already distinct directories for the Kafka and RabbitMQ binding examples (i.e. `processor-samples/reactive-processor-kafka` and `processor-samples/reactive-processor-rabbit`) I removed the `docker-compose-rabbit.yml` file from the Kafka binding example directory `processor-samples/reactive-processor-kafka` and updated it's `README.md` accordingly.